### PR TITLE
Updated to Hibernate 5.2 using the JPA Criteria API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     compile 'org.springframework.boot:spring-boot-starter-thymeleaf'
     compile 'org.hashids:hashids:1.0.1'
     compile 'org.springframework:spring-orm:4.2.5.RELEASE'
-    compile 'org.hibernate:hibernate-core:5.1.0.Final'
+    compile 'org.hibernate:hibernate-core:5.2.1.Final'
     compile 'org.apache.tomcat:tomcat-dbcp:8.0.32'
     compile 'com.h2database:h2:1.4.191'
 }

--- a/src/main/java/com/teamtreehouse/giflib/dao/CategoryDaoImpl.java
+++ b/src/main/java/com/teamtreehouse/giflib/dao/CategoryDaoImpl.java
@@ -7,6 +7,8 @@ import org.hibernate.SessionFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
 import java.util.List;
 
 @Repository
@@ -20,8 +22,20 @@ public class CategoryDaoImpl implements CategoryDao {
         // Open a session
         Session session = sessionFactory.openSession();
 
-        // Get all categories with a Hibernate criteria
-        List<Category> categories = session.createCriteria(Category.class).list();
+        // DEPRECATED as of Hibernate 5.2.0
+        // List<Category> categories = session.createCriteria(Category.class).list();
+
+        // Create CriteriaBuilder
+        CriteriaBuilder builder = session.getCriteriaBuilder();
+
+        // Create CriteriaQuery
+        CriteriaQuery<Category> criteria = builder.createQuery(Category.class);
+
+        // Specify criteria root
+        criteria.from(Category.class);
+
+        // Execute query
+        List<Category> categories = session.createQuery(criteria).getResultList();
 
         // Close session
         session.close();

--- a/src/main/java/com/teamtreehouse/giflib/dao/GifDaoImpl.java
+++ b/src/main/java/com/teamtreehouse/giflib/dao/GifDaoImpl.java
@@ -6,6 +6,8 @@ import org.hibernate.SessionFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
 import java.util.List;
 
 @Repository
@@ -17,7 +19,21 @@ public class GifDaoImpl implements GifDao {
     @SuppressWarnings("unchecked")
     public List<Gif> findAll() {
         Session session = sessionFactory.openSession();
-        List<Gif> gifs = session.createCriteria(Gif.class).list();
+
+        // DEPRECATED as of Hibernate 5.2.0
+        // List<Gif> gifs = session.createCriteria(Gif.class).list();
+
+        // Create CriteriaBuilder
+        CriteriaBuilder builder = session.getCriteriaBuilder();
+
+        // Create CriteriaQuery
+        CriteriaQuery<Gif> criteria = builder.createQuery(Gif.class);
+
+        // Specify criteria root
+        criteria.from(Gif.class);
+
+        // Execute query
+        List<Gif> gifs = session.createQuery(criteria).getResultList();
 
         session.close();
         return gifs;

--- a/src/main/java/com/teamtreehouse/giflib/web/controller/CategoryController.java
+++ b/src/main/java/com/teamtreehouse/giflib/web/controller/CategoryController.java
@@ -4,8 +4,6 @@ import com.teamtreehouse.giflib.model.Category;
 import com.teamtreehouse.giflib.service.CategoryService;
 import com.teamtreehouse.giflib.web.Color;
 import com.teamtreehouse.giflib.web.FlashMessage;
-import org.hibernate.Session;
-import org.hibernate.SessionFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -16,7 +14,6 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import javax.validation.Valid;
-import java.util.ArrayList;
 import java.util.List;
 
 @Controller

--- a/src/main/resources/app.properties
+++ b/src/main/resources/app.properties
@@ -6,6 +6,7 @@ giflib.entity.package = com.teamtreehouse.giflib.model
 
 # Details for our datasource
 giflib.db.driver = org.h2.Driver
-giflib.db.url = jdbc:h2:tcp://localhost/~/Code/screencasts/giflib-hibernate/data/giflib
+giflib.db.url = jdbc:h2:mem:giflib
+#giflib.db.url = jdbc:h2:tcp://localhost/~/Code/screencasts/giflib-hibernate/data/giflib
 giflib.db.username = sa
 giflib.db.password =


### PR DESCRIPTION
Hibernate 5.2 deprecates the `createCriteria` approach to fetching entities. This PR demonstrates an updated approach for Hibernate 5.2.1 that utilizes the JPA Criteria API found at http://docs.jboss.org/hibernate/orm/5.2/userguide/html_single/Hibernate_User_Guide.html#criteria
